### PR TITLE
Fixed Position encoder for speed up

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ pip install positional-encodings
 ## Usage (PyTorch):
 
 The repo comes with the three main positional encoding models,
-`PositionalEncoding{1,2,3}D`. In addition, there is a `Summer` class that adds
-the input tensor to the positional encodings. See the first example for more info.
+`PositionalEncoding{1,2,3}D`. In addition, there are a `Summer` class that adds
+the input tensor to the positional encodings a and `FixEncoding` class for when 
+dealing with a fixed input shape. that greatly decreases the run time. See the first example for more info.
 
 ```python3
 import torch
@@ -38,9 +39,13 @@ p_enc_1d_model = PositionalEncoding1D(10)
 # Return the inputs with the position encoding added
 p_enc_1d_model_sum = Summer(PositionalEncoding1D(10))
 
+# Returns the same as p_enc_1d_model but much faster
+p_enc_1d_model_fixed = FixEncoding(PositionalEncoding1D(10), (6, ))
+
 x = torch.rand(1,6,10)
 penc_no_sum = p_enc_1d_model(x) # penc_no_sum.shape == (1, 6, 10)
 penc_sum = p_enc_1d_model_sum(x)
+penc_fixed = p_enc_1d_model_fixed(x) # This ran 100x faster
 print(penc_no_sum + x == penc_sum) # True
 ```
 

--- a/positional_encodings/__init__.py
+++ b/positional_encodings/__init__.py
@@ -1,6 +1,8 @@
 from positional_encodings.positional_encodings import (
     PositionalEncoding1D,
     PositionalEncoding2D,
+    SinglePositionalEncoding2D,
+    FixedPositionalEncoding2D,
     PositionalEncoding3D,
     PositionalEncodingPermute1D,
     PositionalEncodingPermute2D,

--- a/positional_encodings/__init__.py
+++ b/positional_encodings/__init__.py
@@ -1,12 +1,11 @@
 from positional_encodings.positional_encodings import (
     PositionalEncoding1D,
     PositionalEncoding2D,
-    SinglePositionalEncoding2D,
-    FixedPositionalEncoding2D,
     PositionalEncoding3D,
     PositionalEncodingPermute1D,
     PositionalEncodingPermute2D,
     PositionalEncodingPermute3D,
+    FixEncoding,
 )
 from positional_encodings.summer import Summer, TFSummer
 from positional_encodings.tf_positional_encodings import (

--- a/positional_encodings/positional_encodings.py
+++ b/positional_encodings/positional_encodings.py
@@ -45,6 +45,10 @@ class PositionalEncodingPermute1D(nn.Module):
         enc = self.penc(tensor)
         return enc.permute(0, 2, 1)
 
+    @property
+    def org_channels(self):
+        return self.penc.org_channels
+
 
 class PositionalEncoding2D(nn.Module):
     def __init__(self, channels):
@@ -92,6 +96,10 @@ class PositionalEncodingPermute2D(nn.Module):
         tensor = tensor.permute(0, 2, 3, 1)
         enc = self.penc(tensor)
         return enc.permute(0, 3, 1, 2)
+
+    @property
+    def org_channels(self):
+        return self.penc.org_channels
 
 
 class PositionalEncoding3D(nn.Module):
@@ -152,8 +160,21 @@ class PositionalEncodingPermute3D(nn.Module):
         enc = self.penc(tensor)
         return enc.permute(0, 4, 1, 2, 3)
 
+    @property
+    def org_channels(self):
+        return self.penc.org_channels
+
 
 class FixEncoding(nn.Module):
+    """
+        :param pos_encoder: instance of PositionalEncoding1D, PositionalEncoding2D or PositionalEncoding3D
+        :param shape: shape of input, excluding batch and embedding size
+
+        Example:
+        p_enc_2d = FixEncoding(PositionalEncoding2D(32), (x, y)) # for where x and y are the dimensions of your image
+        inputs = torch.randn(64, 128, 128, 32) # where x and y are 128, and 64 is the batch size
+        p_enc_2d(inputs)
+    """
 
     def __init__(self, pos_encoder, shape):
         super(FixEncoding, self).__init__()

--- a/positional_encodings/positional_encodings.py
+++ b/positional_encodings/positional_encodings.py
@@ -51,10 +51,10 @@ class SinglePositionalEncoding2D(nn.Module):
         :param channels: The last dimension of the tensor you want to apply pos emb to.
         """
         super(SinglePositionalEncoding2D, self).__init__()
-        channels = int(np.ceil(channels/4)*2)
+        channels = int(np.ceil(channels / 4) * 2)
         self.channels = channels
-        inv_freq = 1. / (10000 ** (torch.arange(0, channels, 2).float() / channels))
-        self.register_buffer('inv_freq', inv_freq)
+        inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
+        self.register_buffer("inv_freq", inv_freq)
 
     def forward(self, tensor):
         """
@@ -70,11 +70,13 @@ class SinglePositionalEncoding2D(nn.Module):
         sin_inp_y = torch.einsum("i,j->ij", pos_y, self.inv_freq)
         emb_x = torch.cat((sin_inp_x.sin(), sin_inp_x.cos()), dim=-1).unsqueeze(1)
         emb_y = torch.cat((sin_inp_y.sin(), sin_inp_y.cos()), dim=-1)
-        emb = torch.zeros((x,y,self.channels*2),device=tensor.device).type(tensor.type())
-        emb[:,:,:self.channels] = emb_x
-        emb[:,:,self.channels:2*self.channels] = emb_y
+        emb = torch.zeros((x, y, self.channels * 2), device=tensor.device).type(
+            tensor.type()
+        )
+        emb[:, :, : self.channels] = emb_x
+        emb[:, :, self.channels : 2 * self.channels] = emb_y
 
-        return emb[None,:,:,:orig_ch]
+        return emb[None, :, :, :orig_ch]
 
 class FixedPositionalEncoding2D(nn.Module):
     def __init__(self, shape, channels):

--- a/test_suite.py
+++ b/test_suite.py
@@ -103,23 +103,83 @@ def test_torch_summer():
         < 0.0001
     ), "The summer is not working properly!"
 
-def test_torch_2D_fixed_speedup(sample_size=10_000):
+
+def test_torch_fixed_1D_encoding():
+    embeding_dim = 64
+    shape = (13, )
+    batch_sizes = (9, 10, 13, embeding_dim)
+
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-    data = torch.randn(32,8,8,64).to(device)
+
+    enc = PositionalEncoding1D(embeding_dim)
+    enc.to(device)
+    fixed_enc = FixEncoding(enc, shape)
+    fixed_enc.to(device)
+    
+    for batch_size in batch_sizes:
+    
+        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
+
+        out_fixed = fixed_enc(data)
+        out_original = enc(data)
+
+        assert torch.sum(out_original - out_fixed) == 0, "The output of the 1D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
+
+test_torch_fixed_1D_encoding()
+
+def test_torch_fixed_2D_encoding():
+    embeding_dim = 64
+    batch_sizes = (9, 10, 13, embeding_dim)
+    shape = (13, 13)
+
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+    enc = PositionalEncoding2D(embeding_dim)
+    enc.to(device)
+    fixed_enc = FixEncoding(enc, shape)
+    fixed_enc.to(device)
+    
+    for batch_size in batch_sizes:
+        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
+        out_fixed = fixed_enc(data)
+        out_original = enc(data)
+
+        assert torch.sum(out_original - out_fixed) == 0, f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
+
+
+def test_torch_fixed_3D_encoding():
+    embeding_dim = 64
+    batch_sizes = (9, 10, 13, embeding_dim)
+    shape = (13, 13, 13)
+
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+    enc = PositionalEncoding3D(embeding_dim)
+    enc.to(device)
+    fixed_enc = FixEncoding(enc, shape)
+    fixed_enc.to(device)
+    
+    for batch_size in batch_sizes:
+        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
+        out_fixed = fixed_enc(data)
+        out_original = enc(data)
+        print(out_fixed.shape)
+        print(out_original.shape)
+        assert torch.sum(out_original - out_fixed) == 0, f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
 
     # Fixed 
-    pos_enc = FixedPositionalEncoding2D((8,32), 64).to(device)
-    start_time = time.time()
-    for i in range(sample_size):
-        pos_enc(data)
-    print(f"Duration when fixed: {time.time()- start_time}")
+    # pos_enc = FixedPositionalEncoding2D((8,32), 64).to(device)
+    # start_time = time.time()
+    # for i in range(sample_size):
+    #     pos_enc(data)
+    # print(f"Duration when fixed: {time.time()- start_time}")
 
-    # Original
-    pos_enc = PositionalEncoding2D(64).to(device)
-    start_time = time.time()
-    for i in range(sample_size):
-        pos_enc(data)
-    print(f"Duration of original: {time.time()- start_time}")
+    # # Original
+    # pos_enc = PositionalEncoding2D(64).to(device)
+    # start_time = time.time()
+    # for i in range(sample_size):
+    #     pos_enc(data)
+    # print(f"Duration of original: {time.time()- start_time}")
 
 def test_tf_summer():
     model_with_sum = TFSummer(TFPositionalEncoding2D(125))

--- a/test_suite.py
+++ b/test_suite.py
@@ -107,7 +107,7 @@ def test_torch_summer():
 def test_torch_fixed_1D_encoding():
     embeding_dim = 64
     shape = (13, )
-    batch_sizes = (9, 10, 13, embeding_dim)
+    batch_sizes = (9, 10, 13, 16)
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
@@ -125,11 +125,9 @@ def test_torch_fixed_1D_encoding():
 
         assert torch.sum(out_original - out_fixed) == 0, "The output of the 1D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
 
-test_torch_fixed_1D_encoding()
-
 def test_torch_fixed_2D_encoding():
     embeding_dim = 64
-    batch_sizes = (9, 10, 13, embeding_dim)
+    batch_sizes = (9, 10, 13, 16)
     shape = (13, 13)
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
@@ -146,10 +144,9 @@ def test_torch_fixed_2D_encoding():
 
         assert torch.sum(out_original - out_fixed) == 0, f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
 
-
 def test_torch_fixed_3D_encoding():
     embeding_dim = 64
-    batch_sizes = (9, 10, 13, embeding_dim)
+    batch_sizes = (9, 10, 13, 16)
     shape = (13, 13, 13)
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
@@ -166,20 +163,6 @@ def test_torch_fixed_3D_encoding():
         print(out_fixed.shape)
         print(out_original.shape)
         assert torch.sum(out_original - out_fixed) == 0, f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
-
-    # Fixed 
-    # pos_enc = FixedPositionalEncoding2D((8,32), 64).to(device)
-    # start_time = time.time()
-    # for i in range(sample_size):
-    #     pos_enc(data)
-    # print(f"Duration when fixed: {time.time()- start_time}")
-
-    # # Original
-    # pos_enc = PositionalEncoding2D(64).to(device)
-    # start_time = time.time()
-    # for i in range(sample_size):
-    #     pos_enc(data)
-    # print(f"Duration of original: {time.time()- start_time}")
 
 def test_tf_summer():
     model_with_sum = TFSummer(TFPositionalEncoding2D(125))

--- a/test_suite.py
+++ b/test_suite.py
@@ -112,14 +112,14 @@ def test_torch_2D_fixed_speedup(sample_size=10_000):
     start_time = time.time()
     for i in range(sample_size):
         pos_enc(data)
-    print(f"Duration for fixied: {time.time()- start_time}")
+    print(f"Duration when fixed: {time.time()- start_time}")
 
     # Original
     pos_enc = PositionalEncoding2D(64).to(device)
     start_time = time.time()
     for i in range(sample_size):
         pos_enc(data)
-    print(f"Duration for original: {time.time()- start_time}")
+    print(f"Duration of original: {time.time()- start_time}")
 
 def test_tf_summer():
     model_with_sum = TFSummer(TFPositionalEncoding2D(125))

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,11 +1,11 @@
 import numpy as np
 import tensorflow as tf
 import torch
+import time
 
 from positional_encodings import *
 
 tf.config.experimental_run_functions_eagerly(True)
-
 
 def test_torch_1d_correct_shape():
     p_enc_1d = PositionalEncoding1D(10)
@@ -103,6 +103,23 @@ def test_torch_summer():
         < 0.0001
     ), "The summer is not working properly!"
 
+def test_torch_2D_fixed_speedup(sample_size=10_000):
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    data = torch.randn(32,8,8,64).to(device)
+
+    # Fixed 
+    pos_enc = FixedPositionalEncoding2D((8,32), 64).to(device)
+    start_time = time.time()
+    for i in range(sample_size):
+        pos_enc(data)
+    print(f"Duration for fixied: {time.time()- start_time}")
+
+    # Original
+    pos_enc = PositionalEncoding2D(64).to(device)
+    start_time = time.time()
+    for i in range(sample_size):
+        pos_enc(data)
+    print(f"Duration for original: {time.time()- start_time}")
 
 def test_tf_summer():
     model_with_sum = TFSummer(TFPositionalEncoding2D(125))


### PR DESCRIPTION
Hey,

First of all, happy new year and stuff.

I made some small changes to the code such that the code will be 100x faster when you are dealing with a fixed input size.
How it works:
- It generates an positional encoding once
- It repeats it for the batch size (and changes it if needed)

The class is called FixedPositionalEncoding2D. I made an additional class SinglePositionalEncoder2D because the code is very similar to the original version. And how they both reference to that class to reduce duplicate code.
If you want to test the speed difference you can call the "test_torch_2D_fixed_speedup" function in the test suite.

Let me know if you like it. I didn't create a readme part yet because maybe you hate the idea hehe ;).

Cheers!