### PR TITLE
[17] Add a caching layer to posenc :tada:

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ pip install positional-encodings
 
 The repo comes with the three main positional encoding models,
 `PositionalEncoding{1,2,3}D`. In addition, there are a `Summer` class that adds
-the input tensor to the positional encodings a and `FixEncoding` class that
-saves computation by not necessarily computing the tensor every forward pass.
-See the `FixEncoding` section for more info.
+the input tensor to the positional encodings.
 
 ```python3
 import torch
@@ -40,13 +38,9 @@ p_enc_1d_model = PositionalEncoding1D(10)
 # Return the inputs with the position encoding added
 p_enc_1d_model_sum = Summer(PositionalEncoding1D(10))
 
-# Returns the same as p_enc_1d_model but saves it for later
-p_enc_1d_model_fixed = FixEncoding(PositionalEncoding1D(10), (6, ))
-
 x = torch.rand(1,6,10)
 penc_no_sum = p_enc_1d_model(x) # penc_no_sum.shape == (1, 6, 10)
 penc_sum = p_enc_1d_model_sum(x)
-penc_fixed = p_enc_1d_model_fixed(x) # The encoding is saved for later, making subsequent forward passes faster.
 print(penc_no_sum + x == penc_sum) # True
 ```
 
@@ -93,20 +87,6 @@ add_p_enc_2d = TFSummer(TFPositionalEncoding2D(170))
 y = tf.ones((1,8,6,2))
 print(add_p_enc_2d(y) - p_enc_2d(y)) # tf.ones((1,8,6,2))
 ```
-
-## More notes on `FixEncoding`
-
-TLDR: Use this class to speed up model training in almost all cases.
-
-The fix encoding class works as follows: on the first forward pass,
-the positional encoding tensor gets cached in the memory of the class
-`(batch_size, *shape)`. Then, on subsequent forward passes, if
-the input tensor matches the shape of the previously inputted tensor,
-it will use the cached version. This avoids having to make the
-tensor on each forward pass.
-
-TBD: Make this the default behavior, and have it always cache the
-intermediate result.
 
 ## Formulas
 

--- a/positional_encodings/__init__.py
+++ b/positional_encodings/__init__.py
@@ -1,5 +1,4 @@
 from positional_encodings.positional_encodings import (
-    FixEncoding,
     PositionalEncoding1D,
     PositionalEncoding2D,
     PositionalEncoding3D,

--- a/test_suite.py
+++ b/test_suite.py
@@ -106,73 +106,30 @@ def test_torch_summer():
     ), "The summer is not working properly!"
 
 
-def test_torch_fixed_1D_encoding():
-    embeding_dim = 64
-    shape = (13,)
-    batch_sizes = (9, 10, 13, 16)
+def test_torch_1D_cache():
+    p_enc_1d = PositionalEncoding1D(10)
+    x = torch.zeros((1, 6, 10))
+    y = torch.zeros((1, 7, 10))
 
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    assert not p_enc_1d.cached_penc
+    assert p_enc_1d(x).shape == (1, 6, 10)
+    assert p_enc_1d.cached_penc.shape == (1, 6, 10)
 
-    enc = PositionalEncoding1D(embeding_dim)
-    enc.to(device)
-    fixed_enc = FixEncoding(enc, shape)
-    fixed_enc.to(device)
-
-    for batch_size in batch_sizes:
-
-        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
-
-        out_fixed = fixed_enc(data)
-        out_original = enc(data)
-
-        assert (
-            torch.sum(out_original - out_fixed) == 0
-        ), "The output of the 1D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
+    assert p_enc_1d(y).shape == (1, 7, 10)
+    assert p_enc_1d.cached_penc.shape == (1, 7, 10)
 
 
-def test_torch_fixed_2D_encoding():
-    embeding_dim = 64
-    batch_sizes = (9, 10, 13, 16)
-    shape = (13, 13)
+def test_tf_1D_cache():
+    p_enc_1d = TFPositionalEncoding1D(170)
+    x = tf.zeros((1, 1024, 170))
+    y = tf.zeros((1, 100, 170))
 
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    assert not p_enc_1d.cached_penc
+    assert p_enc_1d(x).shape == (1, 1024, 170)
+    assert p_enc_1d.cached_penc.shape == (1, 1024, 170)
 
-    enc = PositionalEncoding2D(embeding_dim)
-    enc.to(device)
-    fixed_enc = FixEncoding(enc, shape)
-    fixed_enc.to(device)
-
-    for batch_size in batch_sizes:
-        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
-        out_fixed = fixed_enc(data)
-        out_original = enc(data)
-
-        assert (
-            torch.sum(out_original - out_fixed) == 0
-        ), f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
-
-
-def test_torch_fixed_3D_encoding():
-    embeding_dim = 64
-    batch_sizes = (9, 10, 13, 16)
-    shape = (13, 13, 13)
-
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-
-    enc = PositionalEncoding3D(embeding_dim)
-    enc.to(device)
-    fixed_enc = FixEncoding(enc, shape)
-    fixed_enc.to(device)
-
-    for batch_size in batch_sizes:
-        data = torch.randn(batch_size, *shape, embeding_dim).to(device)
-        out_fixed = fixed_enc(data)
-        out_original = enc(data)
-        print(out_fixed.shape)
-        print(out_original.shape)
-        assert (
-            torch.sum(out_original - out_fixed) == 0
-        ), f"The output of the 2D Positional encoder and the fixed wrapper are not the same. At batch size {batch_size}"
+    assert p_enc_1d(y).shape == (1, 100, 170)
+    assert p_enc_1d.cached_penc.shape == (1, 100, 170)
 
 
 def test_tf_summer():


### PR DESCRIPTION
This introduces a caching layer to the positional encodings such that every call does not have to remake the pos enc tensor if it was the same shape as before. This should increase speed on subsequent calls to the module.