### PR TITLE
TorchEncodings, Summer: readable assertion message

### DIFF
--- a/positional_encodings/torch_encodings.py
+++ b/positional_encodings/torch_encodings.py
@@ -208,6 +208,6 @@ class Summer(nn.Module):
         assert (
             tensor.size() == penc.size()
         ), "The original tensor size {} and the positional encoding tensor size {} must match!".format(
-            tensor.size, penc.size
+            tensor.size(), penc.size()
         )
         return tensor + penc


### PR DESCRIPTION
Currently assert message looks like:

```
AssertionError: The original tensor size <built-in method size of Tensor object at 0x10b6c6310> and the positional encoding tensor size <built-in method size of Tensor object at 0x183344cc0> must match!
```

And with this change would be like:

```
AssertionError: The original tensor size torch.Size([15, 784, 39]) and the positional encoding tensor size torch.Size([15, 40, 39]) must match!
```