### PR TITLE
TFEncodings, Summer: readable assertion message

### DIFF
--- a/positional_encodings/tf_encodings.py
+++ b/positional_encodings/tf_encodings.py
@@ -197,6 +197,6 @@ class TFSummer(tf.keras.layers.Layer):
         assert (
             tensor.shape == penc.shape
         ), "The original tensor size {} and the positional encoding tensor size {} must match!".format(
-            tensor.size, penc.size
+            tensor.shape, penc.shape
         )
         return tensor + penc


### PR DESCRIPTION
Currently an error like the following is shown when tensor shapes do not match:

```
AttributeError: Tensor object has no attribute 'size'.
          If you are looking for numpy-related methods, please run the following:
          from tensorflow.python.ops.numpy_ops import np_config
          np_config.enable_numpy_behavior()
```

With this change the error would look like:

```
AssertionError: The original tensor size (1, 5, 180) and the positional encoding tensor size (1, 5, 2) must match!
```
