### PR TITLE
feat: make sure the summed output is on the same device as the input

### DIFF
--- a/positional_encodings/torch_encodings.py
+++ b/positional_encodings/torch_encodings.py
@@ -204,7 +204,7 @@ class Summer(nn.Module):
         :param tensor: A 3, 4 or 5d tensor that matches the model output size
         :return: Positional Encoding Matrix summed to the original tensor
         """
-        penc = self.penc(tensor)
+        penc = self.penc(tensor).to(tensor.device)
         assert (
             tensor.size() == penc.size()
         ), "The original tensor size {} and the positional encoding tensor size {} must match!".format(

--- a/positional_encodings/torch_encodings.py
+++ b/positional_encodings/torch_encodings.py
@@ -22,7 +22,7 @@ class PositionalEncoding1D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.cached_penc = None
+        self.register_buffer("cached_penc", None)
 
     def forward(self, tensor):
         """
@@ -76,7 +76,7 @@ class PositionalEncoding2D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.cached_penc = None
+        self.register_buffer("cached_penc", None)
 
     def forward(self, tensor):
         """
@@ -138,7 +138,7 @@ class PositionalEncoding3D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.cached_penc = None
+        self.register_buffer("cached_penc", None)
 
     def forward(self, tensor):
         """
@@ -204,7 +204,7 @@ class Summer(nn.Module):
         :param tensor: A 3, 4 or 5d tensor that matches the model output size
         :return: Positional Encoding Matrix summed to the original tensor
         """
-        penc = self.penc(tensor).to(tensor.device)
+        penc = self.penc(tensor)
         assert (
             tensor.size() == penc.size()
         ), "The original tensor size {} and the positional encoding tensor size {} must match!".format(


### PR DESCRIPTION
Hi,

I really enjoy using your library. I just wanted to suggest a small feature addition for the `Summer` class in PyTorch. Currently, it seems that the positional encoding layer outputs are always on the CPU (or am I mistaken?). Consequently, when using the `Summer` module, there can be a mismatch between the input and output devices, leading to a crash during forwarding.

To address this issue, I made a minor modification to prevent such mismatches.

I haven't made any changes to the way the TF layers work, but it might be beneficial to implement a similar solution if it hasn't been done already. (I haven't used that library before, so I'm not sure.) If you think it would be helpful, I can create another commit for the TF Summer layer.

Thank you for your time and for developing this library.

Pierre