### PR TITLE
Make cached_penc a non-persistent buffer in PyTorch bindings.

### DIFF
--- a/positional_encodings/torch_encodings.py
+++ b/positional_encodings/torch_encodings.py
@@ -22,7 +22,7 @@ class PositionalEncoding1D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.register_buffer("cached_penc", None)
+        self.register_buffer("cached_penc", None, persistent=False)
 
     def forward(self, tensor):
         """
@@ -76,7 +76,7 @@ class PositionalEncoding2D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.register_buffer("cached_penc", None)
+        self.register_buffer("cached_penc", None, persistent=False)
 
     def forward(self, tensor):
         """
@@ -140,7 +140,7 @@ class PositionalEncoding3D(nn.Module):
         self.channels = channels
         inv_freq = 1.0 / (10000 ** (torch.arange(0, channels, 2).float() / channels))
         self.register_buffer("inv_freq", inv_freq)
-        self.register_buffer("cached_penc", None)
+        self.register_buffer("cached_penc", None, persistent=False)
 
     def forward(self, tensor):
         """


### PR DESCRIPTION
https://github.com/tatp22/multidim-positional-encoding/pull/31 added a fix to ensure that the `cached_penc` buffer was present on the appropriate device; however, when this change was later [released in v6.0.2](https://github.com/tatp22/multidim-positional-encoding/pull/35), this added an additional key to [the `state_dict` of the module](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer), causing any existing models trained with this module to fail to load.

This PR fixes the issue by adding `persistent=False` so that the `cached_penc` buffer is not saved in the module's `state_dict` on disk.

IMO 6.0.2 contained a breaking change for existing PyTorch codebases and should be [yanked](https://peps.python.org/pep-0592/) from PyPI.

(cc @pierrot-lc)